### PR TITLE
Migrate to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,20 @@ yarn install
 
 Copy `.env.example` to `.env` and put in your [Etherscan API Key](https://etherscan.io/apis).
 
-To download all the challenges (specified on challenges.json), run:
+To download all the challenges specified on `challenges.json`, run:
+
 ```
-node install
+yarn install-challenges <create-eth version>
 ```
+
+The `create-eth version` parameter is optional and should only be used for development purposes. If omitted, the latest stable create-eth version for extensions will be used.
 
 You can rerun the install anytime to update all the repos.
 
 **Note**: For challenge 2, you have to manually create a `YourTokenAutograder.sol` file inside `challenge-2-token-vendor/packages/hardhat/contracts`
 
 ```solidity
-pragma solidity 0.8.4;
+pragma solidity 0.8.20; // Do not change the solidity version as it negativly impacts submission grading
 // SPDX-License-Identifier: MIT
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -36,22 +39,24 @@ contract YourToken is ERC20 {
 ---
 
 For local dev, you can run:
+
 ```bash
 yarn server
 ```
 
 now visit http://localhost:54727/
 
-- For pretty feedback, visit: http://localhost:54727/0/rinkeby/0x43Ab1FCd430C1f20270C2470f857f7a006117bbb
+- For pretty feedback, visit: http://localhost:54727/0/sepolia.etherscan.io/0x6976571037372EeDF61Ca174b0eca4f6995d9d04
 - The main API endpoint is a POST to http://localhost:54727/. E.g:
+
 ```
 POST http://localhost:54727
 Content-Type: application/json
 
 {
   "challenge": 0,
-  "network": "rinkeby",
-  "address": "0x43Ab1FCd430C1f20270C2470f857f7a006117bbb"
+  "blockExplorer": "sepolia.etherscan.io",
+  "address": "0x6976571037372EeDF61Ca174b0eca4f6995d9d04"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -30,23 +30,20 @@ app.get("/address", async function (req, res) {
 });
 
 // For testing purposes.
-app.get("/:challengeId/:network/:address", async function (req, res) {
-  console.log("GET /:challengeId/:network/:address", req.params);
+app.get("/:challengeId/:blockExplorer/:address", async function (req, res) {
+  console.log("GET /:challengeId/:blockExplorer/:address", req.params);
   const challengeId = req.params.challengeId;
-  const network = req.params.network;
-  const blockExplorer = req.body.blockExplorer;
+  const blockExplorer = req.params.blockExplorer;
   // To avoid case-sensitive conflicts.
   const address = req.params.address.toLowerCase();
 
   let result;
   try {
-    result = await downloadAndTestContract(challengeId, network, address);
     result = await downloadAndTestContract(challengeId, blockExplorer, address);
   } catch (e) {
     return res.status(200).send(`
       <html>
         <body>
-           <p>Can't get the contract from ${network} in ${address}.</p>
            <p>Can't get the contract from ${blockExplorer} in ${address}.</p>
            <p>${e.message}</p>${MESSAGES.telegramHelp(challenges[challengeId])}
         </body>

--- a/install.js
+++ b/install.js
@@ -30,7 +30,7 @@ const setupChallenge = async (challenge) => {
     // If installation was successful, swap the folders
     if (fs.existsSync(tempFolder)) {
       if (fs.existsSync(`./${challenge.name}`)) {
-        console.log(`🗑  Removing old ${challenge.name}`);
+        console.log(`🗑  Removing old ${challenge.name} folder`);
         fs.rmSync(`./${challenge.name}`, { recursive: true, force: true });
       }
 

--- a/install.js
+++ b/install.js
@@ -4,37 +4,58 @@ const exec = util.promisify(require("child_process").exec);
 
 const challenges = JSON.parse(fs.readFileSync("challenges.json").toString());
 
+const CREATE_ETH_STABLE_VERSION_FOR_CHALLENGES = "0.0.65";
+const createEthVersion =
+  process.argv[2] || CREATE_ETH_STABLE_VERSION_FOR_CHALLENGES;
+
 const setupChallenge = async (challenge) => {
   try {
-    if (!fs.existsSync(`./${challenge.name}`)) {
-      console.log("====] CLONING " + challenge.name + "[==============]");
-      const result1 = await exec(
-        "git clone -b " +
-          challenge.name +
-          " " +
-          challenge.github +
-          " " +
-          challenge.name
-      );
-      console.log(`stdout: ${result1.stdout}\n`);
+    const tempFolder = `./${challenge.name}_temp`;
+
+    if (fs.existsSync(tempFolder)) {
+      console.log(`🗑  Removing old temporary folder of ${challenge.name}`);
+      fs.rmSync(tempFolder, { recursive: true, force: true });
+    }
+
+    console.log(`📦 Installing ${challenge.name} to temporary folder`);
+    const result1 = await exec(
+      `npx --yes create-eth@${createEthVersion} -s hardhat -e scaffold-eth/se-2-challenges:${challenge.name}--extension ${tempFolder}`
+    );
+    // console.log(`stdout: ${result1.stdout}\n`);
+
+    if (result1.stderr) {
       console.log(`stderr: ${result1.stderr}\n`);
     }
 
-    console.log("====] UPDATING " + challenge.name + "[==============]");
-    const result2 = await exec(
-      "cd " + challenge.name + " && git pull && yarn install"
-    );
-    console.log(`stdout: ${result2.stdout}\n`);
-    console.log(`stderr: ${result2.stderr}\n`);
+    // If installation was successful, swap the folders
+    if (fs.existsSync(tempFolder)) {
+      if (fs.existsSync(`./${challenge.name}`)) {
+        console.log(`🗑  Removing old ${challenge.name}`);
+        fs.rmSync(`./${challenge.name}`, { recursive: true, force: true });
+      }
+
+      console.log(`📂 Moving new installation to final location`);
+      fs.renameSync(tempFolder, `./${challenge.name}`);
+    }
   } catch (e) {
-    console.log(e);
+    console.log(`❌ Error installing ${challenge.name}:`, e);
+    // Clean up temp folder if it exists
+    if (fs.existsSync(`./${challenge.name}_new`)) {
+      fs.rmSync(`./${challenge.name}_new`, { recursive: true, force: true });
+    }
   }
 };
 
 (async () => {
   for (let c in challenges) {
     let challenge = challenges[c];
-    console.log("challenge", challenge);
+    console.log(
+      `\n📋 Processing challenge ${c}/${Object.keys(challenges).length}:`
+    );
+
+    console.log(`🔍 Challenge ${c} details:`, challenge);
     await setupChallenge(challenge);
+    console.log(`✅ Challenge ${c} installation completed`);
   }
+  console.log("✨ All challenge installations completed!");
 })();

--- a/install.js
+++ b/install.js
@@ -40,8 +40,8 @@ const setupChallenge = async (challenge) => {
   } catch (e) {
     console.log(`❌ Error installing ${challenge.name}:`, e);
     // Clean up temp folder if it exists
-    if (fs.existsSync(`./${challenge.name}_new`)) {
-      fs.rmSync(`./${challenge.name}_new`, { recursive: true, force: true });
+    if (fs.existsSync(`./${challenge.name}_temp`)) {
+      fs.rmSync(`./${challenge.name}_temp`, { recursive: true, force: true });
     }
   }
 };

--- a/install.js
+++ b/install.js
@@ -4,7 +4,7 @@ const exec = util.promisify(require("child_process").exec);
 
 const challenges = JSON.parse(fs.readFileSync("challenges.json").toString());
 
-const CREATE_ETH_STABLE_VERSION_FOR_CHALLENGES = "0.0.65";
+const CREATE_ETH_STABLE_VERSION_FOR_CHALLENGES = "0.1.0";
 const createEthVersion =
   process.argv[2] || CREATE_ETH_STABLE_VERSION_FOR_CHALLENGES;
 
@@ -19,7 +19,7 @@ const setupChallenge = async (challenge) => {
 
     console.log(`📦 Installing ${challenge.name} to temporary folder`);
     const result1 = await exec(
-      `npx --yes create-eth@${createEthVersion} -s hardhat -e scaffold-eth/se-2-challenges:${challenge.name}--extension ${tempFolder}`
+      `npx --yes create-eth@${createEthVersion} -s hardhat -e scaffold-eth/se-2-challenges:${challenge.name} ${tempFolder}`
     );
     // console.log(`stdout: ${result1.stdout}\n`);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "nodemon": "^2.0.15"
   },
   "scripts": {
-    "server": "nodemon index"
+    "server": "nodemon index",
+    "install-challenges": "node install.js"
   },
   "nodemonConfig": {
     "ignore": [

--- a/utils/contract.js
+++ b/utils/contract.js
@@ -87,18 +87,18 @@ const testChallenge = async ({ challenge, blockExplorer, address }) => {
     address,
   };
   try {
-    console.log("====] RUNNING " + challenge.name + "[==============]");
+    console.log(`🚀 Running ${challenge.name}`);
 
     const { stdout } = await exec(
       "cd " + challenge.name + " && CONTRACT_ADDRESS=" + address + " yarn test"
     );
 
-    console.log("Tests passed successfully!\n");
+    console.log("✅ Tests passed successfully!\n");
     result.success = true;
     // Maybe we don't want this when succeeding.
     result.feedback = `${MESSAGES.successTest(challenge)}<pre>${stdout}</pre>`;
   } catch (e) {
-    console.error("Test failed", JSON.stringify(e), "\n");
+    console.error("❌ Test failed", JSON.stringify(e), "\n");
 
     result.success = false;
     // ToDo. Parse this and gives a better feedback.
@@ -131,7 +131,7 @@ const downloadAndTestContract = async (challengeId, blockExplorer, address) => {
   }
 
   if (!VALID_BLOCK_EXPLORER_HOSTS.includes(blockExplorer)) {
-    throw new Error(`"${blockExplorer}" is not a valid testnet.`);
+    throw new Error(`"${blockExplorer}" is not a valid block explorer.`);
   }
 
   console.log(`📡 Downloading contract from ${blockExplorer}`);


### PR DESCRIPTION
Changed installation from cloning challenges to using `create-eth`. 
How it works for every challenge: 
1. Challenge is installing in a temporary folder, so if something goes wrong, the previous challenge version still exists
2. if challenge is installed to temp folder as expected, previous version is removed and the new version is added instead 

Also
- `yarn install-challenges <create-eth version>` script
- README/console.logs adjustements

Current installation logs:
```
...
✅ Challenge 3 installation completed

📋 Processing challenge 4/6:
🔍 Challenge 4 details: {
  id: 4,
  name: 'challenge-4-dex',
  github: 'https://github.com/scaffold-eth/se-2-challenges.git',
  contractName: 'DEX',
  telegram: 'https://t.me/+_NeUIJ664Tc1MzIx',
  successMessage: '<p>You have successfully passed the Dex Challenge! Great work!</p><p>--</p>'
}
📦 Installing challenge-4-dex to temporary folder
🗑 Removing old challenge-4-dex folder
📂 Moving new installation to final location
✅ Challenge 4 installation completed

📋 Processing challenge 5/6:
...
```