### PR TITLE
Relative paths

### DIFF
--- a/challenges.js
+++ b/challenges.js
@@ -93,10 +93,10 @@ const challenges = {
   "challenge-oracles": {
     name: "challenge-oracles",
     github: "https://github.com/scaffold-eth/se-2-challenges.git",
-    contractName: "OptimisticOracle",
+    contractName: "02_Optimistic/OptimisticOracle",
     testName: "OptimisticOracle.ts",
     telegram: "https://t.me/+AkmcMB3jC3A0NDcx",
-    requiredInitialContracts: ["Decider.sol"],
+    requiredInitialContracts: ["02_Optimistic/Decider.sol"],
     successMessage:
       "<p>You have successfully passed the Oracles Challenge! Great work!</p><p>--</p>",
   },

--- a/install.js
+++ b/install.js
@@ -188,6 +188,7 @@ async function downloadAllTestFiles(options = {}) {
 
       for (const contractFile of challengeData.requiredInitialContracts) {
         try {
+          // remove
           // Construct the contract file path in the repo
           const contractRepoFilePath = `extension/packages/hardhat/contracts/${contractFile}`;
 
@@ -198,8 +199,13 @@ async function downloadAllTestFiles(options = {}) {
             challengeData.name
           );
 
+          // remove possible folders from the path from contractFile
+          const contractFileName = contractFile.split("/").pop();
           // Destination file path for the contract
-          const contractDestinationPath = path.join(contractsDir, contractFile);
+          const contractDestinationPath = path.join(
+            contractsDir,
+            contractFileName
+          );
 
           console.log(`\tContract From: ${contractDownloadUrl}`);
           console.log(`\tContract To: ${contractDestinationPath}`);

--- a/install.js
+++ b/install.js
@@ -188,7 +188,6 @@ async function downloadAllTestFiles(options = {}) {
 
       for (const contractFile of challengeData.requiredInitialContracts) {
         try {
-          // remove
           // Construct the contract file path in the repo
           const contractRepoFilePath = `extension/packages/hardhat/contracts/${contractFile}`;
 
@@ -199,13 +198,8 @@ async function downloadAllTestFiles(options = {}) {
             challengeData.name
           );
 
-          // remove possible folders from the path from contractFile
-          const contractFileName = contractFile.split("/").pop();
           // Destination file path for the contract
-          const contractDestinationPath = path.join(
-            contractsDir,
-            contractFileName
-          );
+          const contractDestinationPath = path.join(contractsDir, contractFile);
 
           console.log(`\tContract From: ${contractDownloadUrl}`);
           console.log(`\tContract To: ${contractDestinationPath}`);


### PR DESCRIPTION
Merged #35 but it has a few issues:

- Need to fix the path (both contracts are inside a folder)
- Removed the folders when saving it locally (not sure if needed)

> Error HH404: File ./OptimisticOracle.sol, imported from contracts/Decider.sol

Since `Decider` is importing `OptimisticOracle.sol`... and it's not there, since the name is "download-0xAddress). I guess it's the first time that a requiredContract is importing the "result" contract.

Can you take a look @rin-st and explore options?